### PR TITLE
fix: fix SDK cannot properly parse client token permissions

### DIFF
--- a/defaultclient.go
+++ b/defaultclient.go
@@ -130,7 +130,6 @@ func (client *DefaultClient) ValidatePermission(claims *JWTClaims, requiredPermi
 	}
 
 	if client.permissionAllowed(claims.Permissions, requiredPermission) {
-		log("ValidatePermission: permission allowed to access resource")
 		return true, nil
 	}
 

--- a/defaultclient.go
+++ b/defaultclient.go
@@ -17,13 +17,14 @@ package ic
 import (
 	"context"
 	"crypto/rsa"
+	"net/http"
+	"strings"
+	"time"
+
 	"github.com/AccelByte/go-restful-plugins/v3/pkg/jaeger"
 	"github.com/bluele/gcache"
 	"github.com/pkg/errors"
 	"go.uber.org/atomic"
-	"net/http"
-	"strings"
-	"time"
 )
 
 const (
@@ -127,6 +128,12 @@ func (client *DefaultClient) ValidatePermission(claims *JWTClaims, requiredPermi
 	for placeholder, value := range permissionResources {
 		requiredPermission.Resource = strings.Replace(requiredPermission.Resource, placeholder, value, 1)
 	}
+
+	if client.permissionAllowed(claims.Permissions, requiredPermission) {
+		log("ValidatePermission: permission allowed to access resource")
+		return true, nil
+	}
+
 	for _, role := range claims.Roles {
 		rolePermission, err := client.GetRolePermissions(role.RoleID)
 		if err != nil {

--- a/models.go
+++ b/models.go
@@ -15,8 +15,9 @@
 package ic
 
 import (
-	"github.com/AccelByte/go-jose/jwt"
 	"time"
+
+	"github.com/AccelByte/go-jose/jwt"
 )
 
 const (
@@ -60,11 +61,12 @@ type ClaimRole struct {
 
 // JWTClaims holds data stored in a JWT access token with additional Justice Flags field
 type JWTClaims struct {
-	OrganizationID string      `json:"organizationId"`
-	DisplayName    string      `json:"display_name"`
-	Roles          []ClaimRole `json:"roles"`
-	Scope          string      `json:"scope"`
-	ClientID       string      `json:"client_id"`
+	OrganizationID string       `json:"organizationId"`
+	DisplayName    string       `json:"display_name"`
+	Roles          []ClaimRole  `json:"roles"`
+	Scope          string       `json:"scope"`
+	ClientID       string       `json:"client_id"`
+	Permissions    []Permission `json:"permissions"`
 	jwt.Claims
 }
 


### PR DESCRIPTION
Previously, the SDK is only usable for user tokens, since in user tokens we are taking the stuff from `roles`. However, for client tokens, unfortunately we don't have `roles` (it's only empty array); and we need to get the permissions from the `permissions` field instead (inside the JWT claims).

I am mostly following the example in iam-go-sdk here: https://github.com/AccelByte/iam-go-sdk/blob/master/defaultclient.go#L429-L432. I have posted the result in Slack, seems all good for both user token and client token.